### PR TITLE
test against 0.4 and 0.5 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - osx
 
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: DrKrar@live.com


### PR DESCRIPTION
release is 0.5 now, should still test against 0.4 if it's still supported